### PR TITLE
Make every admin page mobile-friendly

### DIFF
--- a/frontend/src/app/admin/[tab]/page.tsx
+++ b/frontend/src/app/admin/[tab]/page.tsx
@@ -61,7 +61,7 @@ export default function AdminTabbedPage() {
   return (
     <div className="min-h-screen flex flex-col w-full overflow-x-hidden" style={{ background: 'var(--color-bg)' }}>
       <header
-        className="hidden min-[1450px]:flex flex-wrap items-center gap-3 sm:gap-4 px-4 sm:px-6 py-3 sm:py-4 border-b justify-between"
+        className="hidden lg:flex flex-wrap items-center gap-3 sm:gap-4 px-4 sm:px-6 py-3 sm:py-4 border-b justify-between"
         style={{
           background: 'var(--color-bg-elevated)',
           borderColor: 'var(--color-divider)'
@@ -91,7 +91,7 @@ export default function AdminTabbedPage() {
               }`}
             >
               <span className="text-lg">{tab.icon}</span>
-              <span className="hidden sm:inline">{tab.label}</span>
+              <span className="hidden xl:inline">{tab.label}</span>
             </button>
           ))}
         </nav>
@@ -106,36 +106,44 @@ export default function AdminTabbedPage() {
       </header>
 
       <header
-        className="flex min-[1450px]:hidden items-center justify-between gap-3 px-4 py-3 border-b"
+        className="flex lg:hidden flex-col gap-2 px-3 py-3 border-b"
         style={{ background: 'var(--color-bg-elevated)', borderColor: 'var(--color-divider)' }}
       >
-        <div className="flex items-center gap-3 shrink-0">
-          <div className="w-10 h-10">
-            <img src="/logo.svg" alt="Kinboard Logo" className="w-full h-full" />
+       <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 shrink-0">
+            <div className="w-9 h-9">
+              <img src="/logo.svg" alt="Kinboard Logo" className="w-full h-full" />
+            </div>
+            <span className="font-semibold text-base" style={{ color: 'var(--color-text)' }}>Kinboard</span>
           </div>
-          <span className="hidden sm:block font-semibold" style={{ color: 'var(--color-text)' }}>Kinboard</span>
+
+          <button
+            className="rounded-lg"
+            style={{ width: 'var(--touch-target)', height: 'var(--touch-target)' }}
+            aria-label="Open menu"
+            onClick={() => setIsMenuOpen(true)}
+          >
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--color-text)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+          </button>
         </div>
 
-        <div className="flex-1 min-w-0 text-center">
-          <div className="flex items-center justify-center gap-2 truncate">
-            <span className="text-base font-medium truncate" style={{ color: 'var(--color-text)' }}>
-              {tabs[currentTabIndex]?.label}
-            </span>
-          </div>
-        </div>
-
-        <button
-          className="rounded-lg"
-          style={{ width: 'var(--touch-target-lg)', height: 'var(--touch-target-lg)' }}
-          aria-label="Open menu"
-          onClick={() => setIsMenuOpen(true)}
-        >
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--color-text)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="12" x2="21" y2="12" />
-            <line x1="3" y1="18" x2="21" y2="18" />
-          </svg>
-        </button>
+        <nav className="tab-list-scroll" aria-label="Admin sections">
+          {tabs.map((tab, index) => (
+            <button
+              key={tab.id}
+              onClick={() => handleTabChange(index)}
+              className={`tab flex items-center gap-2 ${currentTabIndex === index ? 'tab-active' : ''}`}
+              style={{ padding: '0.625rem 1rem' }}
+            >
+              <span className="text-lg" aria-hidden="true">{tab.icon}</span>
+              <span>{tab.label}</span>
+            </button>
+          ))}
+        </nav>
       </header>
 
       {isMenuOpen && (
@@ -148,7 +156,7 @@ export default function AdminTabbedPage() {
           <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)' }} onClick={() => setIsMenuOpen(false)} />
 
           <div
-            className="relative ml-auto mr-auto w-full max-w-200 rounded-b-2xl border shadow-lg animate-slide-up"
+            className="relative ml-auto mr-auto w-full max-w-xl rounded-b-2xl border shadow-lg animate-slide-up"
             style={{ background: 'var(--color-bg-elevated)', borderColor: 'var(--color-divider)' }}
           >
             <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: 'var(--color-divider)' }}>
@@ -206,7 +214,7 @@ export default function AdminTabbedPage() {
         </div>
       )}
 
-      <main className="flex-1 overflow-auto p-4 sm:p-6">
+      <main className="flex-1 overflow-auto p-3 sm:p-6">
         <div className="max-w-5xl mx-auto">
           {!adminEnabled ? (
             <div className="empty-state">

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -82,7 +82,7 @@ export default function AdminLoginPage() {
 
       {/* Login Form */}
       <div
-        className="card-elevated w-full max-w-md p-8"
+        className="card-elevated w-full max-w-md p-6 sm:p-8"
       >
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -385,12 +385,12 @@ button, [role="button"] {
 .card-grid {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
 }
 
 @media (min-width: 1280px) {
   .card-grid {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
   }
 }
 
@@ -428,7 +428,13 @@ button, [role="button"] {
 .input-sm {
   padding: 0.5rem 0.75rem;
   font-size: var(--text-sm);
-  min-height: 36px;
+  min-height: 40px;
+}
+
+@media (max-width: 640px) {
+  .input-sm {
+    min-height: var(--touch-target);
+  }
 }
 
 /* Select dropdown */
@@ -506,7 +512,8 @@ button, [role="button"] {
 }
 
 /* Dialog/Modal styling */
-.dialog-overlay {
+.dialog-overlay,
+.modal-backdrop {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
@@ -516,24 +523,43 @@ button, [role="button"] {
   justify-content: center;
   z-index: 50;
   animation: fadeIn 0.15s ease;
+  padding: 1rem;
+  overflow-y: auto;
 }
 
-.dialog {
+.dialog,
+.modal-content {
   background: var(--color-bg-elevated);
   border-radius: var(--radius-xl);
   border: 1px solid var(--color-divider);
   box-shadow: var(--shadow-lg);
   width: 100%;
   max-width: 480px;
-  max-height: 90vh;
+  max-height: calc(100vh - 2rem);
   overflow: hidden;
   display: flex;
   flex-direction: column;
   animation: slideUp 0.2s ease;
 }
 
+.modal-content {
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
 .dialog-lg {
   max-width: 640px;
+}
+
+@media (max-width: 640px) {
+  .dialog-overlay,
+  .modal-backdrop {
+    padding: 0.5rem;
+  }
+  .dialog,
+  .modal-content {
+    max-height: calc(100vh - 1rem);
+  }
 }
 
 .dialog-header {
@@ -560,6 +586,16 @@ button, [role="button"] {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 480px) {
+  .dialog-footer {
+    flex-direction: column-reverse;
+  }
+  .dialog-footer > * {
+    width: 100%;
+  }
 }
 
 /* Icon button */
@@ -582,8 +618,15 @@ button, [role="button"] {
 }
 
 .icon-btn-sm {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
+}
+
+@media (max-width: 640px) {
+  .icon-btn-sm {
+    width: var(--touch-target);
+    height: var(--touch-target);
+  }
 }
 
 .icon-btn-danger:hover {
@@ -696,6 +739,8 @@ button, [role="button"] {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
   margin-bottom: 1.5rem;
 }
 
@@ -704,6 +749,12 @@ button, [role="button"] {
   font-weight: 600;
   color: var(--color-text);
   margin: 0;
+}
+
+@media (max-width: 480px) {
+  .section-header > .btn {
+    flex: 1 1 auto;
+  }
 }
 
 /* List item for admin lists */
@@ -724,4 +775,169 @@ button, [role="button"] {
 
 .list-item + .list-item {
   margin-top: 0.5rem;
+}
+
+/* ============================================
+   Mobile admin patterns
+   ============================================ */
+
+/* Show on desktop, hide on mobile (admin tables) */
+.admin-table-desktop {
+  display: none;
+}
+
+/* Show on mobile, hide on desktop (admin card list) */
+.admin-cards-mobile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .admin-table-desktop {
+    display: block;
+  }
+  .admin-cards-mobile {
+    display: none;
+  }
+}
+
+/* Card-row used as mobile alternative to table rows */
+.admin-card-row {
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-md);
+  padding: 0.875rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-card-row-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.admin-card-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.admin-card-row-meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.75rem;
+  font-size: var(--text-sm);
+}
+
+.admin-card-row-meta dt {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.admin-card-row-meta dd {
+  color: var(--color-text);
+  margin: 0;
+  word-break: break-word;
+  min-width: 0;
+}
+
+/* Reorder buttons - touch-friendly alternative to drag handles */
+.reorder-btns {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.reorder-btns .icon-btn {
+  width: var(--touch-target);
+  height: calc(var(--touch-target) / 2);
+  min-height: 0;
+  border-radius: var(--radius-sm);
+}
+
+@media (min-width: 768px) {
+  .reorder-btns .icon-btn {
+    height: 20px;
+    width: 32px;
+  }
+}
+
+.reorder-btns .icon-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* Custom file input - wraps native input with styled label */
+.file-input-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.file-input-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  font-size: var(--text-base);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-divider);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  min-height: var(--touch-target);
+}
+
+.file-input-label:hover {
+  background: var(--color-surface-hover);
+}
+
+.file-input-wrapper input[type="file"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.file-input-name {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  word-break: break-all;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+/* Horizontally scrolling tab list for mobile */
+.tab-list-scroll {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.tab-list-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.tab-list-scroll > .tab {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { AuthProvider } from "@/contexts/AuthContext";
 import "./globals.css";
@@ -19,6 +19,12 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.svg",
   },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/frontend/src/components/admin/CalendarsAdmin.tsx
+++ b/frontend/src/components/admin/CalendarsAdmin.tsx
@@ -38,6 +38,18 @@ const IconGripVertical = () => (
   </svg>
 );
 
+const IconChevronUp = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="18 15 12 9 6 15" />
+  </svg>
+);
+
+const IconChevronDown = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
 export default function CalendarsAdmin() {
   const [items, setItems] = useState<CalendarSource[]>([]);
   const [loading, setLoading] = useState(true);
@@ -88,6 +100,20 @@ export default function CalendarsAdmin() {
       await calendarsApi.updateOrder(items.map((u) => u.id));
     } catch (e: any) {
       setError(e?.message || 'Failed to update order');
+    }
+  };
+
+  const moveItem = async (index: number, direction: -1 | 1) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= items.length) return;
+    const reordered = [...items];
+    [reordered[index], reordered[newIndex]] = [reordered[newIndex], reordered[index]];
+    setItems(reordered);
+    try {
+      await calendarsApi.updateOrder(reordered.map((u) => u.id));
+    } catch (e: any) {
+      setError(e?.message || 'Failed to update order');
+      await load();
     }
   };
 
@@ -146,12 +172,12 @@ export default function CalendarsAdmin() {
         </div>
       )}
 
-      {/* Calendars Table */}
-      <div className="card overflow-hidden">
+      {/* Desktop Calendars Table */}
+      <div className="admin-table-desktop card overflow-hidden">
         <table className="table">
           <thead>
             <tr>
-              <th style={{ width: 48 }}></th>
+              <th style={{ width: 96 }}></th>
               <th style={{ width: '20%' }}>Name</th>
               <th>iCal URL</th>
               <th style={{ width: 80 }}>Color</th>
@@ -160,7 +186,7 @@ export default function CalendarsAdmin() {
             </tr>
           </thead>
           <tbody>
-            {items.map((it) => (
+            {items.map((it, idx) => (
               <tr
                 key={it.id}
                 draggable
@@ -170,9 +196,17 @@ export default function CalendarsAdmin() {
                 style={{ opacity: draggingId === it.id ? 0.5 : 1 }}
               >
                 <td>
-                  <span className="drag-handle">
-                    <IconGripVertical />
-                  </span>
+                  <div className="flex items-center gap-1">
+                    <span className="drag-handle"><IconGripVertical /></span>
+                    <div className="reorder-btns">
+                      <button className="icon-btn" onClick={() => moveItem(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                        <IconChevronUp />
+                      </button>
+                      <button className="icon-btn" onClick={() => moveItem(idx, 1)} disabled={idx === items.length - 1} aria-label="Move down">
+                        <IconChevronDown />
+                      </button>
+                    </div>
+                  </div>
                 </td>
                 <td>
                   <input
@@ -185,7 +219,8 @@ export default function CalendarsAdmin() {
                 </td>
                 <td>
                   <input
-                    type="text"
+                    type="url"
+                    inputMode="url"
                     className="input input-sm"
                     value={it.icalUrl}
                     onChange={e => setItems(arr => arr.map(a => a.id === it.id ? { ...a, icalUrl: e.target.value } : a))}
@@ -215,16 +250,16 @@ export default function CalendarsAdmin() {
                 </td>
                 <td>
                   <div className="flex items-center justify-end gap-1">
-                    <button 
-                      className="icon-btn icon-btn-sm" 
+                    <button
+                      className="icon-btn icon-btn-sm"
                       onClick={() => saveItem(it)}
                       aria-label="Save"
                       title="Save changes"
                     >
                       <IconSave />
                     </button>
-                    <button 
-                      className="icon-btn icon-btn-sm icon-btn-danger" 
+                    <button
+                      className="icon-btn icon-btn-sm icon-btn-danger"
                       onClick={() => removeItem(it.id)}
                       aria-label="Delete"
                     >
@@ -248,31 +283,135 @@ export default function CalendarsAdmin() {
         </table>
       </div>
 
+      {/* Mobile Calendar Cards */}
+      <div className="admin-cards-mobile">
+        {items.map((it, idx) => (
+          <div key={it.id} className="admin-card-row">
+            <div className="admin-card-row-header">
+              <div className="color-swatch shrink-0" style={{ background: it.colorHex, width: 28, height: 28 }} />
+              <div className="flex-1 min-w-0">
+                <input
+                  type="text"
+                  className="input input-sm"
+                  value={it.name}
+                  onChange={e => setItems(arr => arr.map(a => a.id === it.id ? { ...a, name: e.target.value } : a))}
+                  placeholder="Calendar name"
+                />
+              </div>
+              <div className="reorder-btns shrink-0">
+                <button className="icon-btn" onClick={() => moveItem(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                  <IconChevronUp />
+                </button>
+                <button className="icon-btn" onClick={() => moveItem(idx, 1)} disabled={idx === items.length - 1} aria-label="Move down">
+                  <IconChevronDown />
+                </button>
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label className="label" style={{ marginBottom: '0.25rem' }}>iCal URL</label>
+              <input
+                type="url"
+                inputMode="url"
+                className="input input-sm"
+                value={it.icalUrl}
+                onChange={e => setItems(arr => arr.map(a => a.id === it.id ? { ...a, icalUrl: e.target.value } : a))}
+                placeholder="https://..."
+              />
+            </div>
+
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <label className="flex items-center gap-2">
+                <button
+                  className={`switch ${it.enabled ? 'switch-checked' : ''}`}
+                  onClick={() => setItems(arr => arr.map(a => a.id === it.id ? { ...a, enabled: !a.enabled } : a))}
+                  role="switch"
+                  aria-checked={it.enabled}
+                >
+                  <span className="switch-thumb" />
+                </button>
+                <span style={{ color: 'var(--color-text)', fontSize: 'var(--text-sm)' }}>
+                  {it.enabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </label>
+              <ColorPicker
+                value={it.colorHex}
+                onChange={(val) => setItems(arr => arr.map(a => a.id === it.id ? { ...a, colorHex: val } : a))}
+                showText={false}
+                allowCustom={false}
+                variant="popover"
+              />
+            </div>
+
+            <div className="admin-card-row-actions">
+              <button className="btn btn-primary flex-1" onClick={() => saveItem(it)}>
+                <IconSave />
+                Save
+              </button>
+              <button
+                className="btn btn-secondary"
+                style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+                onClick={() => removeItem(it.id)}
+                aria-label={`Delete ${it.name}`}
+              >
+                <IconTrash />
+              </button>
+            </div>
+          </div>
+        ))}
+        {items.length === 0 && (
+          <div className="empty-state">
+            <div className="empty-state-icon">📅</div>
+            <p>No calendars yet</p>
+          </div>
+        )}
+      </div>
+
       {/* Add New Calendar */}
       <div className="mt-6">
-        <h3 
+        <h3
           className="text-lg font-medium mb-3"
           style={{ color: 'var(--color-text)' }}
         >
           Add Calendar
         </h3>
         <div className="card p-4">
-          <div className="grid gap-4" style={{ gridTemplateColumns: '1fr 2fr auto auto auto' }}>
-            <input
-              type="text"
-              className="input"
-              value={newItem.name}
-              onChange={e => setNewItem({ ...newItem, name: e.target.value })}
-              placeholder="Calendar name"
-            />
-            <input
-              type="text"
-              className="input"
-              value={newItem.icalUrl}
-              onChange={e => setNewItem({ ...newItem, icalUrl: e.target.value })}
-              placeholder="iCal URL (https://...)"
-            />
-            <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-3">
+            <div className="form-group">
+              <label className="label">Name</label>
+              <input
+                type="text"
+                className="input"
+                value={newItem.name}
+                onChange={e => setNewItem({ ...newItem, name: e.target.value })}
+                placeholder="Calendar name"
+              />
+            </div>
+            <div className="form-group">
+              <label className="label">iCal URL</label>
+              <input
+                type="url"
+                inputMode="url"
+                className="input"
+                value={newItem.icalUrl}
+                onChange={e => setNewItem({ ...newItem, icalUrl: e.target.value })}
+                placeholder="https://..."
+              />
+            </div>
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <label className="flex items-center gap-2">
+                <button
+                  className={`switch ${newItem.enabled ? 'switch-checked' : ''}`}
+                  onClick={() => setNewItem({ ...newItem, enabled: !newItem.enabled })}
+                  role="switch"
+                  aria-checked={newItem.enabled}
+                >
+                  <span className="switch-thumb" />
+                </button>
+                <span style={{ color: 'var(--color-text)', fontSize: 'var(--text-sm)' }}>
+                  {newItem.enabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </label>
               <ColorPicker
                 value={newItem.colorHex}
                 onChange={(val) => setNewItem({ ...newItem, colorHex: val })}
@@ -282,21 +421,12 @@ export default function CalendarsAdmin() {
               />
             </div>
             <button
-              className={`switch ${newItem.enabled ? 'switch-checked' : ''}`}
-              onClick={() => setNewItem({ ...newItem, enabled: !newItem.enabled })}
-              role="switch"
-              aria-checked={newItem.enabled}
-              style={{ alignSelf: 'center' }}
-            >
-              <span className="switch-thumb" />
-            </button>
-            <button 
               className="btn btn-primary"
               onClick={addItem}
               disabled={!newItem.name || !newItem.icalUrl}
             >
               <IconPlus />
-              <span>Add</span>
+              <span>Add Calendar</span>
             </button>
           </div>
         </div>

--- a/frontend/src/components/admin/JobsAdmin.tsx
+++ b/frontend/src/components/admin/JobsAdmin.tsx
@@ -46,6 +46,18 @@ const IconGripVertical = () => (
   </svg>
 );
 
+const IconChevronUp = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="18 15 12 9 6 15" />
+  </svg>
+);
+
+const IconChevronDown = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
 function formatDateInput(d?: string) {
   if (!d) return '';
   // Parse the ISO date string and format as YYYY-MM-DD in local timezone
@@ -351,6 +363,20 @@ export default function JobsAdmin() {
     }
   };
 
+  const moveJob = async (index: number, direction: -1 | 1) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= jobs.length) return;
+    const reordered = [...jobs];
+    [reordered[index], reordered[newIndex]] = [reordered[newIndex], reordered[index]];
+    setJobs(reordered);
+    try {
+      await jobApi.updateOrder(reordered.map((j) => j.id));
+    } catch (e: any) {
+      setError(e?.message || 'Failed to update order');
+      await load();
+    }
+  };
+
   // Get users not already assigned
   const availableUsers = users.filter(u => 
     !form.assignments?.some(a => a.userId === u.id) || 
@@ -359,8 +385,8 @@ export default function JobsAdmin() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-4">
-        <div>
+      <div className="section-header" style={{ marginBottom: 0 }}>
+        <div className="min-w-0">
           <h2 className="text-xl font-semibold" style={{ color: 'var(--color-text)' }}>
             Jobs
           </h2>
@@ -370,7 +396,7 @@ export default function JobsAdmin() {
         </div>
         <button className="btn btn-primary" onClick={openCreate}>
           <IconPlus />
-          New Job
+          <span>New Job</span>
         </button>
       </div>
 
@@ -384,7 +410,8 @@ export default function JobsAdmin() {
         </div>
       )}
 
-      <div className="overflow-auto">
+      {/* Desktop table */}
+      <div className="admin-table-desktop overflow-auto card">
         <table className="table">
           <thead>
             <tr>
@@ -396,7 +423,7 @@ export default function JobsAdmin() {
             </tr>
           </thead>
           <tbody>
-            {jobs.map((c) => (
+            {jobs.map((c, idx) => (
               <tr
                 key={c.id}
                 draggable
@@ -408,8 +435,18 @@ export default function JobsAdmin() {
                   background: draggingId === c.id ? 'var(--color-surface)' : undefined,
                 }}
               >
-                <td className="p-2 cursor-grab" style={{ color: 'var(--color-text-muted)' }}>
-                  <IconGripVertical />
+                <td className="p-2" style={{ color: 'var(--color-text-muted)' }}>
+                  <div className="flex items-center gap-1">
+                    <span className="drag-handle"><IconGripVertical /></span>
+                    <div className="reorder-btns">
+                      <button className="icon-btn" onClick={() => moveJob(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                        <IconChevronUp />
+                      </button>
+                      <button className="icon-btn" onClick={() => moveJob(idx, 1)} disabled={idx === jobs.length - 1} aria-label="Move down">
+                        <IconChevronDown />
+                      </button>
+                    </div>
+                  </div>
                 </td>
                 <td>
                   <div className="flex flex-col gap-1">
@@ -477,6 +514,82 @@ export default function JobsAdmin() {
         </table>
       </div>
 
+      {/* Mobile cards */}
+      <div className="admin-cards-mobile">
+        {jobs.map((c, idx) => (
+          <div key={c.id} className="admin-card-row">
+            <div className="admin-card-row-header">
+              <div className="flex-1 min-w-0">
+                <div style={{ color: 'var(--color-text)', fontWeight: 600 }}>{c.title}</div>
+                {c.description && (
+                  <div style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
+                    {c.description}
+                  </div>
+                )}
+              </div>
+              <div className="reorder-btns shrink-0">
+                <button className="icon-btn" onClick={() => moveJob(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                  <IconChevronUp />
+                </button>
+                <button className="icon-btn" onClick={() => moveJob(idx, 1)} disabled={idx === jobs.length - 1} aria-label="Move down">
+                  <IconChevronDown />
+                </button>
+              </div>
+            </div>
+
+            <dl className="admin-card-row-meta">
+              <dt>Assigned</dt>
+              <dd>
+                {(c.assignments?.length || 0) > 0 ? (
+                  <div className="flex items-center gap-2 flex-wrap">
+                    {c.assignments?.slice(0, 5).map((a) => (
+                      <span
+                        key={a.id}
+                        className="avatar avatar-sm"
+                        title={a.user?.displayName || ''}
+                        style={{ background: a.user?.colorHex || '#777', color: 'white' }}
+                      >
+                        {a.user?.displayName?.charAt(0) || '?'}
+                      </span>
+                    ))}
+                    {(c.assignments?.length || 0) > 5 && (
+                      <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
+                        +{(c.assignments?.length || 0) - 5}
+                      </span>
+                    )}
+                  </div>
+                ) : (
+                  <span style={{ color: 'var(--color-text-muted)' }}>Unassigned</span>
+                )}
+              </dd>
+              <dt>Recurrence</dt>
+              <dd>{c.recurrence || '—'}</dd>
+            </dl>
+
+            <div className="admin-card-row-actions">
+              <button className="btn btn-secondary flex-1" onClick={() => openEdit(c)}>
+                <IconEdit />
+                Edit
+              </button>
+              <button
+                className="btn btn-secondary"
+                style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+                onClick={() => remove(c)}
+                aria-label={`Delete ${c.title}`}
+              >
+                <IconTrash />
+              </button>
+            </div>
+          </div>
+        ))}
+        {!loading && jobs.length === 0 && (
+          <div className="empty-state">
+            <div className="empty-state-icon">✓</div>
+            <p>No jobs yet</p>
+          </div>
+        )}
+      </div>
+
       {/* Job Dialog */}
       {open && (
         <div className="dialog-overlay" onClick={closeDialog}>
@@ -521,7 +634,7 @@ export default function JobsAdmin() {
                       />
                       <button
                         className="btn btn-secondary text-sm"
-                        style={{ minHeight: '36px', color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+                        style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
                         onClick={async () => {
                           try {
                             await jobApi.deleteImage(editing.id);
@@ -536,11 +649,17 @@ export default function JobsAdmin() {
                       </button>
                     </div>
                   )}
-                  <input
-                    type="file"
-                    accept="image/png,image/jpeg,image/webp"
-                    onChange={(e) => setImageFile(e.target.files?.[0] || null)}
-                  />
+                  <div className="file-input-wrapper">
+                    <label className="file-input-label">
+                      {imageFile ? 'Change Image' : 'Choose Image'}
+                      <input
+                        type="file"
+                        accept="image/png,image/jpeg,image/webp"
+                        onChange={(e) => setImageFile(e.target.files?.[0] || null)}
+                      />
+                    </label>
+                    {imageFile && <span className="file-input-name">{imageFile.name}</span>}
+                  </div>
                   <p style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
                     Max 5 MB. PNG/JPG/WebP.
                   </p>
@@ -552,7 +671,7 @@ export default function JobsAdmin() {
                     <label className="label" style={{ marginBottom: 0 }}>
                       Recurrence
                     </label>
-                    <button className="btn btn-secondary text-sm" style={{ minHeight: '36px' }} onClick={openRecurrence}>
+                    <button className="btn btn-secondary text-sm" onClick={openRecurrence}>
                       Edit Recurrence
                     </button>
                   </div>
@@ -585,7 +704,6 @@ export default function JobsAdmin() {
                     </label>
                     <button
                       className="btn btn-secondary text-sm"
-                      style={{ minHeight: '36px' }}
                       onClick={openAddAssignment}
                       disabled={availableUsers.length === 0}
                     >
@@ -737,7 +855,6 @@ export default function JobsAdmin() {
                       </label>
                       <button
                         className="btn btn-secondary text-sm"
-                        style={{ minHeight: '36px' }}
                         onClick={() => setAssignmentRecurrenceOpen(true)}
                       >
                         Edit

--- a/frontend/src/components/admin/KioskTokensAdmin.tsx
+++ b/frontend/src/components/admin/KioskTokensAdmin.tsx
@@ -11,6 +11,19 @@ interface KioskTokenWithUrl {
   url: string;
 }
 
+const IconCheck = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const IconCopy = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
 export default function KioskTokensAdmin() {
   const [tokens, setTokens] = useState<KioskToken[]>([]);
   const [loading, setLoading] = useState(true);
@@ -18,6 +31,7 @@ export default function KioskTokensAdmin() {
   const [open, setOpen] = useState(false);
   const [tokenName, setTokenName] = useState('');
   const [createdToken, setCreatedToken] = useState<KioskTokenWithUrl | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   const load = async () => {
     try {
@@ -79,8 +93,14 @@ export default function KioskTokensAdmin() {
     }
   };
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+  const copyToClipboard = async (text: string, key: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKey(key);
+      setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 1500);
+    } catch {
+      setError('Failed to copy to clipboard');
+    }
   };
 
   return (
@@ -107,8 +127,8 @@ export default function KioskTokensAdmin() {
         </div>
       )}
 
-      {/* Tokens List */}
-      <div className="card overflow-hidden">
+      {/* Desktop Tokens List */}
+      <div className="admin-table-desktop card overflow-hidden">
         <table className="table">
           <thead>
             <tr>
@@ -154,7 +174,6 @@ export default function KioskTokensAdmin() {
                       <button
                         className="btn btn-secondary text-sm"
                         onClick={() => revokeToken(token.id, token.name)}
-                        style={{ minHeight: '36px' }}
                       >
                         Revoke
                       </button>
@@ -175,6 +194,50 @@ export default function KioskTokensAdmin() {
             )}
           </tbody>
         </table>
+      </div>
+
+      {/* Mobile Tokens Cards */}
+      <div className="admin-cards-mobile">
+        {tokens.map((token) => (
+          <div key={token.id} className="admin-card-row">
+            <div className="admin-card-row-header">
+              <div className="flex-1 min-w-0">
+                <div style={{ color: 'var(--color-text)', fontWeight: 600 }} className="truncate">
+                  {token.name}
+                </div>
+                <div style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
+                  Created {new Date(token.createdAt).toLocaleDateString()}
+                </div>
+              </div>
+              {token.isActive ? (
+                <span className="px-2 py-1 rounded text-xs font-medium shrink-0" style={{ background: 'var(--color-success-muted)', color: 'var(--color-success)' }}>
+                  Active
+                </span>
+              ) : (
+                <span className="px-2 py-1 rounded text-xs font-medium shrink-0" style={{ background: 'var(--color-error-muted)', color: 'var(--color-error)' }}>
+                  Revoked
+                </span>
+              )}
+            </div>
+            {token.isActive && (
+              <div className="admin-card-row-actions">
+                <button
+                  className="btn btn-secondary flex-1"
+                  style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+                  onClick={() => revokeToken(token.id, token.name)}
+                >
+                  Revoke
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+        {!loading && tokens.length === 0 && (
+          <div className="empty-state">
+            <div className="empty-state-icon">🔑</div>
+            <p>No kiosk tokens yet</p>
+          </div>
+        )}
       </div>
 
       {/* Create Token Dialog */}
@@ -216,42 +279,40 @@ export default function KioskTokensAdmin() {
                     </p>
                   </div>
 
-                  <div>
+                  <div className="form-group">
                     <label className="label">Kiosk URL</label>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        className="input flex-1"
-                        value={createdToken.url}
-                        readOnly
-                        style={{ fontFamily: 'monospace', fontSize: 'var(--text-sm)' }}
-                      />
-                      <button
-                        className="btn btn-secondary"
-                        onClick={() => copyToClipboard(createdToken.url!)}
-                      >
-                        Copy
-                      </button>
-                    </div>
+                    <input
+                      type="text"
+                      className="input"
+                      value={createdToken.url}
+                      readOnly
+                      onFocus={(e) => e.currentTarget.select()}
+                      style={{ fontFamily: 'monospace', fontSize: 'var(--text-sm)' }}
+                    />
+                    <button
+                      className="btn btn-secondary w-full"
+                      onClick={() => copyToClipboard(createdToken.url!, 'url')}
+                    >
+                      {copiedKey === 'url' ? <><IconCheck /> Copied!</> : <><IconCopy /> Copy URL</>}
+                    </button>
                   </div>
 
-                  <div>
+                  <div className="form-group">
                     <label className="label">Token</label>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        className="input flex-1"
-                        value={createdToken.token}
-                        readOnly
-                        style={{ fontFamily: 'monospace', fontSize: 'var(--text-sm)' }}
-                      />
-                      <button
-                        className="btn btn-secondary"
-                        onClick={() => copyToClipboard(createdToken.token!)}
-                      >
-                        Copy
-                      </button>
-                    </div>
+                    <input
+                      type="text"
+                      className="input"
+                      value={createdToken.token}
+                      readOnly
+                      onFocus={(e) => e.currentTarget.select()}
+                      style={{ fontFamily: 'monospace', fontSize: 'var(--text-sm)' }}
+                    />
+                    <button
+                      className="btn btn-secondary w-full"
+                      onClick={() => copyToClipboard(createdToken.token!, 'token')}
+                    >
+                      {copiedKey === 'token' ? <><IconCheck /> Copied!</> : <><IconCopy /> Copy Token</>}
+                    </button>
                   </div>
                 </div>
               )}

--- a/frontend/src/components/admin/PerformanceAdmin.tsx
+++ b/frontend/src/components/admin/PerformanceAdmin.tsx
@@ -303,9 +303,9 @@ export default function PerformanceAdmin() {
         </div>
       )}
 
-      {/* Detailed Table */}
+      {/* Detailed Table - Desktop */}
       {!loading && !error && data && data.endpoints.length > 0 && (
-        <div className="card overflow-hidden">
+        <div className="admin-table-desktop card overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
@@ -400,6 +400,51 @@ export default function PerformanceAdmin() {
               </tbody>
             </table>
           </div>
+        </div>
+      )}
+
+      {/* Detailed List - Mobile */}
+      {!loading && !error && data && data.endpoints.length > 0 && (
+        <div className="admin-cards-mobile">
+          {data.endpoints.map((endpoint, index) => {
+            const methodColor =
+              endpoint.method === 'GET' ? '#10B981'
+              : endpoint.method === 'POST' ? '#3B82F6'
+              : endpoint.method === 'PUT' ? '#F59E0B'
+              : endpoint.method === 'DELETE' ? '#EF4444'
+              : '#6B7280';
+            return (
+              <div key={index} className="admin-card-row">
+                <div className="admin-card-row-header">
+                  <span
+                    className="px-2 py-1 rounded text-xs font-medium shrink-0"
+                    style={{ backgroundColor: `${methodColor}20`, color: methodColor }}
+                  >
+                    {endpoint.method}
+                  </span>
+                  <span className="font-mono text-sm min-w-0 break-all" style={{ color: 'var(--color-text)' }}>
+                    {endpoint.endpoint}
+                  </span>
+                </div>
+                <dl className="admin-card-row-meta">
+                  <dt>Requests</dt>
+                  <dd className="font-mono">{endpoint.requestCount.toLocaleString()}</dd>
+                  <dt>Avg</dt>
+                  <dd className="font-mono">{endpoint.avgRequestTimeMs.toFixed(2)} ms</dd>
+                  <dt>P95</dt>
+                  <dd className="font-mono">{endpoint.p95RequestTimeMs.toFixed(2)} ms</dd>
+                  <dt>P99</dt>
+                  <dd className="font-mono">{endpoint.p99RequestTimeMs.toFixed(2)} ms</dd>
+                  <dt>Error %</dt>
+                  <dd className="font-mono" style={{ color: endpoint.errorRate > 5 ? 'var(--color-error)' : endpoint.errorRate > 0 ? 'var(--color-warning)' : 'var(--color-success)' }}>
+                    {endpoint.errorRate.toFixed(2)}%
+                  </dd>
+                  <dt>Queries</dt>
+                  <dd className="font-mono">{endpoint.avgQueryCount}</dd>
+                </dl>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/components/admin/ShoppingAdmin.tsx
+++ b/frontend/src/components/admin/ShoppingAdmin.tsx
@@ -37,6 +37,18 @@ const IconGripVertical = () => (
   </svg>
 );
 
+const IconChevronUp = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="18 15 12 9 6 15" />
+  </svg>
+);
+
+const IconChevronDown = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
 export default function ShoppingAdmin() {
   const [lists, setLists] = useState<ShoppingList[]>([]);
   const [loading, setLoading] = useState(true);
@@ -150,6 +162,20 @@ export default function ShoppingAdmin() {
     }
   };
 
+  const moveList = async (index: number, direction: -1 | 1) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= lists.length) return;
+    const reordered = [...lists];
+    [reordered[index], reordered[newIndex]] = [reordered[newIndex], reordered[index]];
+    setLists(reordered);
+    try {
+      await shoppingListApi.updateOrder(reordered.map((l) => l.id));
+    } catch (e: any) {
+      setError(e?.message || 'Failed to update order');
+      await load();
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -167,8 +193,8 @@ export default function ShoppingAdmin() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
+      <div className="section-header" style={{ marginBottom: 0 }}>
+        <div className="min-w-0">
           <h2 className="text-2xl font-bold" style={{ color: 'var(--color-text)' }}>
             Shopping Lists
           </h2>
@@ -204,192 +230,262 @@ export default function ShoppingAdmin() {
           </button>
         </div>
       ) : (
-        <div className="card overflow-hidden">
-          <table className="w-full">
-            <thead>
-              <tr style={{ background: 'var(--color-surface)' }}>
-                <th className="w-10"></th>
-                <th className="text-left p-4 font-semibold" style={{ color: 'var(--color-text)' }}>
-                  List
-                </th>
-                <th className="text-left p-4 font-semibold" style={{ color: 'var(--color-text)' }}>
-                  Items
-                </th>
-                <th className="text-left p-4 font-semibold" style={{ color: 'var(--color-text)' }}>
-                  Color
-                </th>
-                <th className="w-32"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {lists.map((list) => {
-                const importantCount = list.items?.filter((i) => i.isImportant && !i.isBought).length || 0;
-                const unboughtCount = list.items?.filter((i) => !i.isBought).length || 0;
-                return (
-                  <tr
-                    key={list.id}
-                    draggable
-                    onDragStart={() => handleDragStart(list.id)}
-                    onDragEnd={handleDragEnd}
-                    onDragOver={handleDragOver}
-                    onDrop={() => handleDrop(list.id)}
-                    className="border-t transition-colors"
-                    style={{
-                      borderColor: 'var(--color-divider)',
-                      background: draggingId === list.id ? 'var(--color-surface)' : undefined,
-                    }}
-                  >
-                    <td className="p-2 cursor-grab" style={{ color: 'var(--color-text-muted)' }}>
-                      <IconGripVertical />
-                    </td>
-                    <td className="p-4">
-                      <div className="flex items-center gap-3">
-                        {list.avatarUrl ? (
-                          <div className="relative group">
-                            <img
-                              src={list.avatarUrl}
-                              alt={list.name}
-                              className="avatar avatar-md object-cover"
-                              style={{ border: `2px solid ${list.colorHex}` }}
-                            />
-                            <button
-                              onClick={() => handleDeleteAvatar(list)}
-                              className="absolute -top-1 -right-1 w-5 h-5 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-                              style={{ background: 'var(--color-error)', color: 'white' }}
-                              title="Remove avatar"
-                            >
-                              ×
+        <>
+          {/* Desktop Table */}
+          <div className="admin-table-desktop card overflow-hidden">
+            <table className="w-full">
+              <thead>
+                <tr style={{ background: 'var(--color-surface)' }}>
+                  <th className="w-24"></th>
+                  <th className="text-left p-4 font-semibold" style={{ color: 'var(--color-text)' }}>
+                    List
+                  </th>
+                  <th className="text-left p-4 font-semibold" style={{ color: 'var(--color-text)' }}>
+                    Items
+                  </th>
+                  <th className="text-left p-4 font-semibold" style={{ color: 'var(--color-text)' }}>
+                    Color
+                  </th>
+                  <th className="w-32"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {lists.map((list, idx) => {
+                  const importantCount = list.items?.filter((i) => i.isImportant && !i.isBought).length || 0;
+                  const unboughtCount = list.items?.filter((i) => !i.isBought).length || 0;
+                  return (
+                    <tr
+                      key={list.id}
+                      draggable
+                      onDragStart={() => handleDragStart(list.id)}
+                      onDragEnd={handleDragEnd}
+                      onDragOver={handleDragOver}
+                      onDrop={() => handleDrop(list.id)}
+                      className="border-t transition-colors"
+                      style={{
+                        borderColor: 'var(--color-divider)',
+                        background: draggingId === list.id ? 'var(--color-surface)' : undefined,
+                      }}
+                    >
+                      <td className="p-2" style={{ color: 'var(--color-text-muted)' }}>
+                        <div className="flex items-center gap-1">
+                          <span className="drag-handle"><IconGripVertical /></span>
+                          <div className="reorder-btns">
+                            <button className="icon-btn" onClick={() => moveList(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                              <IconChevronUp />
+                            </button>
+                            <button className="icon-btn" onClick={() => moveList(idx, 1)} disabled={idx === lists.length - 1} aria-label="Move down">
+                              <IconChevronDown />
                             </button>
                           </div>
-                        ) : (
-                          <div
-                            className="avatar avatar-md"
-                            style={{ background: list.colorHex, color: 'white' }}
-                          >
-                            {list.name[0]?.toUpperCase()}
-                          </div>
-                        )}
-                        <div>
-                          <span className="font-medium" style={{ color: 'var(--color-text)' }}>
-                            {list.name}
-                          </span>
-                          {importantCount > 0 && (
-                            <span
-                              className="ml-2 px-2 py-0.5 rounded-full text-xs font-medium"
-                              style={{ background: 'var(--color-warning-muted)', color: 'var(--color-warning)' }}
-                            >
-                              {importantCount} important
-                            </span>
-                          )}
                         </div>
-                      </div>
-                    </td>
-                    <td className="p-4" style={{ color: 'var(--color-text-secondary)' }}>
-                      {unboughtCount} item{unboughtCount !== 1 ? 's' : ''}
-                    </td>
-                    <td className="p-4">
-                      <div
-                        className="w-8 h-8 rounded-lg"
-                        style={{ background: list.colorHex }}
-                        title={list.colorHex}
+                      </td>
+                      <td className="p-4">
+                        <div className="flex items-center gap-3">
+                          {list.avatarUrl ? (
+                            <div className="relative group">
+                              <img
+                                src={list.avatarUrl}
+                                alt={list.name}
+                                className="avatar avatar-md object-cover"
+                                style={{ border: `2px solid ${list.colorHex}` }}
+                                loading="lazy"
+                              />
+                              <button
+                                onClick={() => handleDeleteAvatar(list)}
+                                className="absolute -top-1 -right-1 w-5 h-5 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                                style={{ background: 'var(--color-error)', color: 'white', minHeight: 0 }}
+                                title="Remove avatar"
+                              >
+                                ×
+                              </button>
+                            </div>
+                          ) : (
+                            <div
+                              className="avatar avatar-md"
+                              style={{ background: list.colorHex, color: 'white' }}
+                            >
+                              {list.name[0]?.toUpperCase()}
+                            </div>
+                          )}
+                          <div>
+                            <span className="font-medium" style={{ color: 'var(--color-text)' }}>
+                              {list.name}
+                            </span>
+                            {importantCount > 0 && (
+                              <span
+                                className="ml-2 px-2 py-0.5 rounded-full text-xs font-medium"
+                                style={{ background: 'var(--color-warning-muted)', color: 'var(--color-warning)' }}
+                              >
+                                {importantCount} important
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="p-4" style={{ color: 'var(--color-text-secondary)' }}>
+                        {unboughtCount} item{unboughtCount !== 1 ? 's' : ''}
+                      </td>
+                      <td className="p-4">
+                        <div
+                          className="w-8 h-8 rounded-lg"
+                          style={{ background: list.colorHex }}
+                          title={list.colorHex}
+                        />
+                      </td>
+                      <td className="p-4">
+                        <div className="flex items-center gap-2 justify-end">
+                          <button
+                            onClick={() => openEdit(list)}
+                            className="icon-btn icon-btn-sm"
+                            aria-label="Edit"
+                            title="Edit"
+                          >
+                            <IconEdit />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(list.id)}
+                            className="icon-btn icon-btn-sm icon-btn-danger"
+                            aria-label="Delete"
+                            title="Delete"
+                          >
+                            <IconTrash />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile Cards */}
+          <div className="admin-cards-mobile">
+            {lists.map((list, idx) => {
+              const importantCount = list.items?.filter((i) => i.isImportant && !i.isBought).length || 0;
+              const unboughtCount = list.items?.filter((i) => !i.isBought).length || 0;
+              return (
+                <div key={list.id} className="admin-card-row">
+                  <div className="admin-card-row-header">
+                    {list.avatarUrl ? (
+                      <img
+                        src={list.avatarUrl}
+                        alt={list.name}
+                        className="avatar avatar-md object-cover shrink-0"
+                        style={{ border: `2px solid ${list.colorHex}` }}
+                        loading="lazy"
                       />
-                    </td>
-                    <td className="p-4">
-                      <div className="flex items-center gap-2 justify-end">
-                        <button
-                          onClick={() => openEdit(list)}
-                          className="btn-ghost p-2 rounded-lg"
-                          style={{ color: 'var(--color-text-secondary)' }}
-                          title="Edit"
-                        >
-                          <IconEdit />
-                        </button>
-                        <button
-                          onClick={() => handleDelete(list.id)}
-                          className="btn-ghost p-2 rounded-lg"
-                          style={{ color: 'var(--color-error)' }}
-                          title="Delete"
-                        >
-                          <IconTrash />
-                        </button>
+                    ) : (
+                      <div className="avatar avatar-md shrink-0" style={{ background: list.colorHex, color: 'white' }}>
+                        {list.name[0]?.toUpperCase()}
                       </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium truncate" style={{ color: 'var(--color-text)' }}>
+                        {list.name}
+                      </div>
+                      <div style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
+                        {unboughtCount} item{unboughtCount !== 1 ? 's' : ''}
+                        {importantCount > 0 && ` · ${importantCount} important`}
+                      </div>
+                    </div>
+                    <div className="reorder-btns shrink-0">
+                      <button className="icon-btn" onClick={() => moveList(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                        <IconChevronUp />
+                      </button>
+                      <button className="icon-btn" onClick={() => moveList(idx, 1)} disabled={idx === lists.length - 1} aria-label="Move down">
+                        <IconChevronDown />
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="admin-card-row-actions">
+                    <button className="btn btn-secondary flex-1" onClick={() => openEdit(list)}>
+                      <IconEdit />
+                      Edit
+                    </button>
+                    <button
+                      className="btn btn-secondary"
+                      style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+                      onClick={() => handleDelete(list.id)}
+                      aria-label={`Delete ${list.name}`}
+                    >
+                      <IconTrash />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
       )}
 
       {/* Create/Edit Dialog */}
       {open && (
-        <div className="modal-backdrop" onClick={closeDialog}>
-          <div
-            className="modal-content"
-            onClick={(e) => e.stopPropagation()}
-            style={{ maxWidth: 500 }}
-          >
-            <h3 className="text-xl font-bold mb-6" style={{ color: 'var(--color-text)' }}>
-              {editing ? 'Edit Shopping List' : 'New Shopping List'}
-            </h3>
-
-            <div className="space-y-4">
-              {/* Name */}
-              <div>
-                <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
-                  Name
-                </label>
-                <input
-                  type="text"
-                  className="input w-full"
-                  value={form.name}
-                  onChange={(e) => setForm({ ...form, name: e.target.value })}
-                  placeholder="e.g., Groceries"
-                  autoFocus
-                />
-              </div>
-
-              {/* Color */}
-              <div>
-                <label className="block text-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
-                  Color
-                </label>
-                <ColorPicker
-                  value={form.colorHex}
-                  onChange={(val) => setForm({ ...form, colorHex: val })}
-                  variant="popover"
-                  showText={false}
-                  allowCustom={false}
-                />
-              </div>
-
-              {/* Avatar */}
-              <div>
-                <label className="block text-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
-                  Avatar (optional)
-                </label>
-                <div className="flex items-center gap-4">
-                  {(editing?.avatarUrl || avatarFile) && (
-                    <img
-                      src={avatarFile ? URL.createObjectURL(avatarFile) : editing?.avatarUrl || ''}
-                      alt="Preview"
-                      className="avatar avatar-lg object-cover"
-                      style={{ border: `2px solid ${form.colorHex}` }}
-                    />
-                  )}
+        <div className="dialog-overlay" onClick={closeDialog}>
+          <div className="dialog" onClick={(e) => e.stopPropagation()}>
+            <div className="dialog-header">
+              <h3 className="dialog-title">
+                {editing ? 'Edit Shopping List' : 'New Shopping List'}
+              </h3>
+            </div>
+            <div className="dialog-content">
+              <div className="flex flex-col gap-4">
+                {/* Name */}
+                <div className="form-group">
+                  <label className="label">Name</label>
                   <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => setAvatarFile(e.target.files?.[0] || null)}
-                    className="text-sm"
-                    style={{ color: 'var(--color-text-secondary)' }}
+                    type="text"
+                    className="input"
+                    value={form.name}
+                    onChange={(e) => setForm({ ...form, name: e.target.value })}
+                    placeholder="e.g., Groceries"
+                    autoFocus
                   />
+                </div>
+
+                {/* Color */}
+                <div className="form-group">
+                  <label className="label">Color</label>
+                  <ColorPicker
+                    value={form.colorHex}
+                    onChange={(val) => setForm({ ...form, colorHex: val })}
+                    variant="popover"
+                    showText={false}
+                    allowCustom={false}
+                  />
+                </div>
+
+                {/* Avatar */}
+                <div className="form-group">
+                  <label className="label">Avatar (optional)</label>
+                  <div className="flex items-center gap-4 flex-wrap">
+                    {(editing?.avatarUrl || avatarFile) && (
+                      <img
+                        src={avatarFile ? URL.createObjectURL(avatarFile) : editing?.avatarUrl || ''}
+                        alt="Preview"
+                        className="avatar avatar-lg object-cover"
+                        style={{ border: `2px solid ${form.colorHex}` }}
+                      />
+                    )}
+                    <div className="file-input-wrapper flex-1">
+                      <label className="file-input-label">
+                        {avatarFile ? 'Change Avatar' : (editing?.avatarUrl ? 'Replace Avatar' : 'Choose Avatar')}
+                        <input
+                          type="file"
+                          accept="image/png,image/jpeg,image/webp"
+                          onChange={(e) => setAvatarFile(e.target.files?.[0] || null)}
+                        />
+                      </label>
+                      {avatarFile && <span className="file-input-name">{avatarFile.name}</span>}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
 
-            <div className="flex justify-end gap-3 mt-8">
+            <div className="dialog-footer">
               <button className="btn btn-secondary" onClick={closeDialog}>
                 Cancel
               </button>

--- a/frontend/src/components/admin/SiteSettingsAdmin.tsx
+++ b/frontend/src/components/admin/SiteSettingsAdmin.tsx
@@ -137,7 +137,7 @@ export default function SiteSettingsAdmin() {
             Refresh Intervals
           </h3>
           
-          <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))' }}>
+          <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(200px, 100%), 1fr))' }}>
             {/* Jobs Refresh */}
             <div className="form-group">
               <label className="label">Jobs Refresh</label>
@@ -206,7 +206,7 @@ export default function SiteSettingsAdmin() {
             Weather API
           </h3>
           
-          <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
+          <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(280px, 100%), 1fr))' }}>
             {/* API Key */}
             <div className="form-group">
               <label className="label">API Key</label>

--- a/frontend/src/components/admin/UsersAdmin.tsx
+++ b/frontend/src/components/admin/UsersAdmin.tsx
@@ -39,6 +39,18 @@ const IconGripVertical = () => (
   </svg>
 );
 
+const IconChevronUp = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="18 15 12 9 6 15" />
+  </svg>
+);
+
+const IconChevronDown = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
 export default function UsersAdmin() {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
@@ -147,6 +159,20 @@ export default function UsersAdmin() {
     }
   };
 
+  const moveUser = async (index: number, direction: -1 | 1) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= users.length) return;
+    const reordered = [...users];
+    [reordered[index], reordered[newIndex]] = [reordered[newIndex], reordered[index]];
+    setUsers(reordered);
+    try {
+      await userApi.updateOrder(reordered.map((u) => u.id));
+    } catch (e: any) {
+      setError(e?.message || 'Failed to update order');
+      await load();
+    }
+  };
+
   const remove = async (u: User) => {
     if (!confirm(`Delete user ${u.displayName}?`)) return;
     try {
@@ -178,12 +204,12 @@ export default function UsersAdmin() {
         </div>
       )}
 
-      {/* Users Table */}
-      <div className="card overflow-hidden">
+      {/* Desktop Users Table */}
+      <div className="admin-table-desktop card overflow-hidden">
         <table className="table">
           <thead>
             <tr>
-              <th style={{ width: 48 }}></th>
+              <th style={{ width: 96 }}></th>
               <th>Display Name</th>
               <th>Email</th>
               <th>Role</th>
@@ -192,7 +218,7 @@ export default function UsersAdmin() {
             </tr>
           </thead>
           <tbody>
-            {users.map((u) => (
+            {users.map((u, idx) => (
               <tr
                 key={u.id}
                 draggable
@@ -202,9 +228,17 @@ export default function UsersAdmin() {
                 style={{ opacity: draggingId === u.id ? 0.5 : 1 }}
               >
                 <td>
-                  <span className="drag-handle">
-                    <IconGripVertical />
-                  </span>
+                  <div className="flex items-center gap-1">
+                    <span className="drag-handle"><IconGripVertical /></span>
+                    <div className="reorder-btns">
+                      <button className="icon-btn" onClick={() => moveUser(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                        <IconChevronUp />
+                      </button>
+                      <button className="icon-btn" onClick={() => moveUser(idx, 1)} disabled={idx === users.length - 1} aria-label="Move down">
+                        <IconChevronDown />
+                      </button>
+                    </div>
+                  </div>
                 </td>
                 <td>
                   <div className="flex items-center gap-3">
@@ -213,6 +247,7 @@ export default function UsersAdmin() {
                         src={u.avatarUrl}
                         alt={u.displayName}
                         className="w-8 h-8 rounded-full object-cover"
+                        loading="lazy"
                       />
                     ) : (
                       <div
@@ -282,6 +317,85 @@ export default function UsersAdmin() {
             )}
           </tbody>
         </table>
+      </div>
+
+      {/* Mobile Users Cards */}
+      <div className="admin-cards-mobile">
+        {users.map((u, idx) => (
+          <div key={u.id} className="admin-card-row">
+            <div className="admin-card-row-header">
+              {u.avatarUrl ? (
+                <img
+                  src={u.avatarUrl}
+                  alt={u.displayName}
+                  className="w-10 h-10 rounded-full object-cover shrink-0"
+                  loading="lazy"
+                />
+              ) : (
+                <div
+                  className="avatar avatar-md shrink-0"
+                  style={{ background: u.colorHex, color: 'white' }}
+                >
+                  {u.displayName.charAt(0)}
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <div style={{ color: 'var(--color-text)', fontWeight: 600 }} className="truncate">
+                  {u.displayName}
+                </div>
+                <div style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }} className="truncate">
+                  {u.email || 'No email'}
+                </div>
+              </div>
+              <div className="reorder-btns shrink-0">
+                <button className="icon-btn" onClick={() => moveUser(idx, -1)} disabled={idx === 0} aria-label="Move up">
+                  <IconChevronUp />
+                </button>
+                <button className="icon-btn" onClick={() => moveUser(idx, 1)} disabled={idx === users.length - 1} aria-label="Move down">
+                  <IconChevronDown />
+                </button>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 flex-wrap">
+              {u.isAdmin && (
+                <span className="px-2 py-1 rounded text-xs font-medium" style={{ background: 'var(--color-primary-muted)', color: 'var(--color-primary)' }}>
+                  Admin
+                </span>
+              )}
+              {u.hideFromKiosk && (
+                <span className="px-2 py-1 rounded text-xs font-medium" style={{ background: 'var(--color-warning-muted)', color: 'var(--color-warning)' }}>
+                  Hidden from kiosk
+                </span>
+              )}
+              <span className="flex items-center gap-1 px-2 py-1 rounded text-xs" style={{ background: 'var(--color-surface)', color: 'var(--color-text-secondary)' }}>
+                <span className="color-swatch" style={{ width: 12, height: 12, borderWidth: 1 }} />
+                {u.colorHex}
+              </span>
+            </div>
+
+            <div className="admin-card-row-actions">
+              <button className="btn btn-secondary flex-1" onClick={() => openEdit(u)}>
+                <IconEdit />
+                Edit
+              </button>
+              <button
+                className="btn btn-secondary"
+                style={{ color: 'var(--color-error)', borderColor: 'var(--color-error)' }}
+                onClick={() => remove(u)}
+                aria-label={`Delete ${u.displayName}`}
+              >
+                <IconTrash />
+              </button>
+            </div>
+          </div>
+        ))}
+        {!loading && users.length === 0 && (
+          <div className="empty-state">
+            <div className="empty-state-icon">👥</div>
+            <p>No users yet</p>
+          </div>
+        )}
       </div>
 
       {/* Dialog */}
@@ -399,47 +513,51 @@ export default function UsersAdmin() {
                   )}
                 </div>
 
-                {/* Avatar (only when editing) */}
-                {editing && (
-                  <div className="form-group">
-                    <label className="label">Avatar</label>
-                    {editing.avatarUrl && (
-                      <div className="flex items-center gap-4 mb-3">
-                        <img
-                          src={editing.avatarUrl}
-                          alt="avatar"
-                          className="w-16 h-16 rounded-full object-cover"
-                        />
-                        <button
-                          className="btn btn-secondary text-sm"
-                          style={{
-                            minHeight: '36px',
-                            color: 'var(--color-error)',
-                            borderColor: 'var(--color-error)'
-                          }}
-                          onClick={async () => {
-                            try {
-                              await userApi.deleteAvatar(editing.id);
-                              setUsers((prev) => prev.map((x) => (x.id === editing.id ? { ...x, avatarUrl: null } : x)));
-                              setEditing({ ...editing, avatarUrl: null });
-                            } catch (e: any) {
-                              setError(e?.message || 'Failed to delete avatar');
-                            }
-                          }}
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    )}
-                    <input
-                      type="file"
-                      accept="image/png,image/jpeg,image/webp"
-                      onChange={(e) => setAvatarFile(e.target.files?.[0] || null)}
-                      className="input"
-                      style={{ padding: '0.5rem' }}
-                    />
+                {/* Avatar */}
+                <div className="form-group">
+                  <label className="label">Avatar</label>
+                  {editing?.avatarUrl && !avatarFile && (
+                    <div className="flex items-center gap-4 mb-3">
+                      <img
+                        src={editing.avatarUrl}
+                        alt="avatar"
+                        className="w-16 h-16 rounded-full object-cover"
+                      />
+                      <button
+                        className="btn btn-secondary text-sm"
+                        style={{
+                          color: 'var(--color-error)',
+                          borderColor: 'var(--color-error)'
+                        }}
+                        onClick={async () => {
+                          try {
+                            await userApi.deleteAvatar(editing.id);
+                            setUsers((prev) => prev.map((x) => (x.id === editing.id ? { ...x, avatarUrl: null } : x)));
+                            setEditing({ ...editing, avatarUrl: null });
+                          } catch (e: any) {
+                            setError(e?.message || 'Failed to delete avatar');
+                          }
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  )}
+                  <div className="file-input-wrapper">
+                    <label className="file-input-label">
+                      {avatarFile ? 'Change Avatar' : (editing?.avatarUrl ? 'Replace Avatar' : 'Choose Avatar')}
+                      <input
+                        type="file"
+                        accept="image/png,image/jpeg,image/webp"
+                        onChange={(e) => setAvatarFile(e.target.files?.[0] || null)}
+                      />
+                    </label>
+                    {avatarFile && <span className="file-input-name">{avatarFile.name}</span>}
                   </div>
-                )}
+                  <p style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
+                    Max 5 MB. PNG/JPG/WebP.
+                  </p>
+                </div>
               </div>
             </div>
             <div className="dialog-footer">

--- a/frontend/src/components/admin/UsersAdmin.tsx
+++ b/frontend/src/components/admin/UsersAdmin.tsx
@@ -424,6 +424,10 @@ export default function UsersAdmin() {
                   <label className="label">Email</label>
                   <input
                     type="email"
+                    inputMode="email"
+                    autoComplete="email"
+                    autoCapitalize="off"
+                    spellCheck={false}
                     className="input"
                     value={form.email || ''}
                     onChange={(e) => setForm((f) => ({ ...f, email: e.target.value || null }))}


### PR DESCRIPTION
## Summary

Makes every admin page work end-to-end on phones. Tables become card lists, drag-and-drop gets a touch fallback, file pickers are styled, dialogs fit the viewport, and the cramped 1450px header breakpoint is gone.

## Foundation

- **Viewport meta**: added to root `layout.tsx`. Without it iOS Safari rendered the whole app at 980px, defeating every responsive utility downstream.
- **`.card-grid` overflow**: `repeat(auto-fit, minmax(280px, 1fr))` was forcing a 280px floor wider than 320px viewports. Switched to `minmax(min(280px, 100%), 1fr)`.
- **Dialogs**: overlay now has padding and overflow-y, dialog max-height respects viewport, footer stacks `column-reverse` below 480px (primary action on top).
- **Touch targets**: `.icon-btn-sm` and `.input-sm` jump to 44px on mobile.
- **`.section-header`** wraps so title + action button stack cleanly.
- **`modal-backdrop` / `modal-content`** classes (used by `ShoppingAdmin` but never defined) are now aliased to the dialog styles. The shopping-list edit dialog was effectively unstyled.
- New utilities: `admin-table-desktop` / `admin-cards-mobile` / `admin-card-row` for swapping table↔card layouts at `md`, `reorder-btns` for the up/down touch fallback, `file-input-wrapper` / `file-input-label` for styled file pickers, `tab-list-scroll` for the new mobile tab strip.

## Admin shell (`admin/[tab]/page.tsx`)

- Header breakpoint moves from `min-[1450px]` → `lg` (1024px). Tablets now get the desktop layout where they have space for it.
- Mobile header is rebuilt: logo + hamburger on top, then a **horizontally scrollable tab strip** so every tab is one tap away. The hamburger drawer remains as a secondary nav with all tabs in a 2-col grid plus the "Back to Kiosk" link.
- Main padding tightened on small screens (`p-3 sm:p-6`).

## Per-page

All six wide-table pages (Jobs, Users, Calendars, Shopping, Kiosk Tokens, Performance) get the same treatment: keep the desktop table, render a card list below `md` with the same data and actions, replace drag handles with up/down reorder buttons (drag-and-drop is mouse-only on touch).

Specifics:

- **JobsAdmin**: file input styled, all `minHeight: '36px'` overrides removed so dialog buttons hit 44px on mobile.
- **UsersAdmin**: avatar upload was hidden behind `{editing && ...}` — now available at create time. Email input gets `inputMode`, `autoComplete`, autocapitalize off, spellcheck off. File input styled.
- **CalendarsAdmin**: the "Add Calendar" form was a 5-column inline grid (`'1fr 2fr auto auto auto'`) that crushed the URL input to ~64px on phones — replaced with a stacked form. Mobile cards keep inline name/URL editing with the same Save button behaviour. `type="url"` + `inputMode="url"` on URL fields.
- **ShoppingAdmin**: dialog rewritten to use real `dialog` / `dialog-content` / `dialog-footer` markup instead of the orphan `modal-backdrop`. File input styled.
- **KioskTokensAdmin**: the kiosk URL + Copy button were a flex row that squeezed the URL on mobile — now stacked, full-width Copy button with "Copied!" feedback.
- **PerformanceAdmin**: 8-column detailed table gets a card list below `md` with the same data and a method-coloured chip.
- **SiteSettingsAdmin**: Refresh Intervals and Weather API grids use `minmax(min(N, 100%), 1fr)` so cards never push beyond viewport.
- **admin/login**: card padding reduced on small screens.

## Test plan

- [ ] Visit every admin tab on a 320px viewport (Jobs, Users, Kiosk, Calendars, Shopping, Performance, Settings) — no horizontal scroll, no clipped content.
- [ ] Reorder via the up/down arrows on Jobs, Users, Calendars, Shopping — order persists.
- [ ] Open the edit dialog on each page — fits the viewport, footer buttons stack on the smallest screens with primary on top.
- [ ] Create a user without entering anything, then pick an avatar before saving — works.
- [ ] Add a new calendar on mobile — name, URL, color, enabled all reachable.
- [ ] Create a kiosk token, tap Copy URL — confirmation appears.
- [ ] Tablet (≥1024px) gets the desktop header with the tab list.
- [ ] Mobile tab strip scrolls horizontally; hamburger drawer still works.

https://claude.ai/code/session_013zX53FyLA8XxKxz3jAt2Fd

---
_Generated by [Claude Code](https://claude.ai/code/session_013zX53FyLA8XxKxz3jAt2Fd)_